### PR TITLE
 Readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before running this script, ensure you have the following installed:
    You can install the required libraries using pip:
 
    ```bash
-   pip install psycopg2-binary faker
+   pip3 install psycopg2-binary faker
    ```
 
 ## Services in the Compose File


### PR DESCRIPTION
Fixes #2
`Python 3.5 pip` has been renamed to `pip3`